### PR TITLE
changed cms/images/plugins to cms/img/icons/plugins

### DIFF
--- a/djangocms_link/cms_plugins.py
+++ b/djangocms_link/cms_plugins.py
@@ -58,6 +58,6 @@ class LinkPlugin(CMSPluginBase):
         return FakeForm(Form, site)
 
     def icon_src(self, instance):
-        return settings.STATIC_URL + u"cms/images/plugins/link.png"
+        return settings.STATIC_URL + u"cms/img/icons/plugins/link.png"
 
 plugin_pool.register_plugin(LinkPlugin)


### PR DESCRIPTION
As defined by divio/django-cms, the file link.png stays in static/cms/img/icons/plugins directory, not in static/cms/images/plugins directory.
