### PR TITLE
Fixed migration and typo in help_text so spurious migration isn't create...

### DIFF
--- a/djangocms_link/migrations_django/0001_initial.py
+++ b/djangocms_link/migrations_django/0001_initial.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(verbose_name='name', max_length=256)),
                 ('url', models.URLField(verbose_name='link', blank=True, null=True)),
                 ('anchor', models.CharField(help_text='This applies only to page and text links.', blank=True, default='', max_length=128, verbose_name='anchor')),
-                ('mailto', models.EmailField(help_text='An email address has priority over a text link.', blank=True, null=True, max_length=75, verbose_name='email address')),
+                ('mailto', models.EmailField(help_text='An email address has priority over a text link.', blank=True, null=True, max_length=75, verbose_name='mailto')),
                 ('phone', models.CharField(help_text='A phone number has priority over a mailto link.', blank=True, null=True, max_length=40, verbose_name='Phone')),
                 ('target', models.CharField(verbose_name='target', blank=True, max_length=100, choices=[('', 'same window'), ('_blank', 'new window'), ('_parent', 'parent window'), ('_top', 'topmost frame')])),
                 ('page_link', models.ForeignKey(help_text='A link to a page has priority over a text link.', on_delete=django.db.models.deletion.SET_NULL, blank=True, verbose_name='page', to='cms.Page', null=True)),

--- a/djangocms_link/models.py
+++ b/djangocms_link/models.py
@@ -21,7 +21,7 @@ class Link(CMSPlugin):
         on_delete=models.SET_NULL
     )
     anchor = models.CharField(_("anchor"), max_length=128, blank=True, help_text=_("This applies only to page and text links."))
-    mailto = models.EmailField(_("mailto"), blank=True, null=True, help_text=_("An email adress has priority over a text link."))
+    mailto = models.EmailField(_("mailto"), blank=True, null=True, help_text=_("An email address has priority over a text link."))
     phone = models.CharField(_('Phone'), blank=True, null=True, max_length=40,
                              help_text=_('A phone number has priority over a mailto link.'))
     target = models.CharField(_("target"), blank=True, max_length=100, choices=((


### PR DESCRIPTION
...d

Strangely the typo was fixed in the migration itself, just not in the model. Django detected the mismatch and wanted to make a migration for it.
The verbose_name was incorrect in the initial migration.
