### PR TITLE
Display `title` instead of `menu title`

### DIFF
--- a/djangocms_link/fields_select2.py
+++ b/djangocms_link/fields_select2.py
@@ -11,6 +11,11 @@ class Select2PageSearchFieldMixin:
         'title_set__menu_title__icontains',
         'title_set__slug__icontains'
     ]
+    
+    def label_from_instance(self, obj):
+        # Display `title` instead of `menu title` returned
+        # by the Page's __str__ method
+        return obj.get_title()
 
 
 class Select2PageSelectWidget(Select2PageSearchFieldMixin, ModelSelect2Widget):


### PR DESCRIPTION
The default object representation of Page model is the `menu title`. It is common to have multiple pages with the same `menu title` but different `title`.