### PR TITLE
Display page title instead of menu title

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Unreleased
+==========
+
+* Display page title instead of menu title
+
 
 3.0.0 (2020-09-02)
 ==================

--- a/djangocms_link/fields_select2.py
+++ b/djangocms_link/fields_select2.py
@@ -12,6 +12,9 @@ class Select2PageSearchFieldMixin:
         'title_set__slug__icontains'
     ]
 
+    def label_from_instance(self, obj):
+        return obj.get_title()
+
 
 class Select2PageSelectWidget(Select2PageSearchFieldMixin, ModelSelect2Widget):
     site = None


### PR DESCRIPTION
The default label for select2 items are the Page's [`__str__` method](https://github.com/django-cms/django-cms/blob/develop/cms/models/pagemodel.py#L256), which displays the page's menu title.

It happens frequently that several pages share the same menu title: they are therefore indistinguishable from each other.

This pull request displays the page's title instead of the menu title.