### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+Unreleased
+==========
+
+* fix: Remove deprecated test suite assertEquals
 
 3.0.0 (2020-09-02)
 ==================

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -90,7 +90,7 @@ class LinkPluginsTestCase(CMSTestCase):
             warnings.simplefilter("ignore")
             response = self.client.post(request_url, data)
 
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         self.assertContains(response, '<div class="success">')
 
     def test_optional_link(self):


### PR DESCRIPTION
The deprecated aliases have been removed in python/cpython#28268 