### PR TITLE
fix: add support of django 4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
           dj30_cms37.txt,
           dj30_cms38.txt,
           dj31_cms38.txt,
+          dj40_cms311.txt,
         ]
         os: [
           ubuntu-20.04,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 Unreleased
 ==========
 
+* Added support for Django 4.0
 * Display page title instead of menu title
 
 

--- a/djangocms_link/models.py
+++ b/djangocms_link/models.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
 
@@ -216,7 +216,7 @@ class AbstractLink(CMSPlugin):
             'internal_link',
         )
 
-        anchor_field_verbose_name = force_text(
+        anchor_field_verbose_name = force_str(
            self._meta.get_field(anchor_field_name).verbose_name)
         anchor_field_value = getattr(self, anchor_field_name)
 
@@ -225,7 +225,7 @@ class AbstractLink(CMSPlugin):
             for key in field_names
         }
         link_field_verbose_names = {
-            key: force_text(self._meta.get_field(key).verbose_name)
+            key: force_str(self._meta.get_field(key).verbose_name)
             for key in link_fields.keys()
         }
         provided_link_fields = {

--- a/tests/requirements/dj40_cms311.txt
+++ b/tests/requirements/dj40_cms311.txt
@@ -1,4 +1,4 @@
 -r base.txt
 
 Django>=4.0,<4.1
-django-cms>=3.11,<3.11
+django-cms>=3.11,<4.0

--- a/tests/requirements/dj40_cms311.txt
+++ b/tests/requirements/dj40_cms311.txt
@@ -1,0 +1,4 @@
+-r base.txt
+
+Django>=4.0,<4.1
+django-cms>=3.11,<3.11


### PR DESCRIPTION
## Description

django-cms 3.11 adds the support of django 4.0 but currently djangocms-link is not compatible with this version of django as there is use of force_text in the codebase. So we remove the use of this deprecated method in favor of `force_str`.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* https://github.com/django-cms/django-cms/blob/release/3.11.x/CHANGELOG.rst#highlights
* https://docs.djangoproject.com/en/4.0/releases/4.0/#features-removed-in-4-0

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
