### PR TITLE
Add support for djangoCMS 4.x

### DIFF
--- a/djangocms_link/fields_select2.py
+++ b/djangocms_link/fields_select2.py
@@ -32,7 +32,7 @@ class Select2PageSelectWidget(Select2PageSearchFieldMixin, ModelSelect2Widget):
             if self.site:
                 return Page.objects.drafts().on_site(self.site)
             return Page.objects.drafts()
-        
+
         # django CMS >= 4
         if self.site:
             return Page.objects.on_site(self.site)

--- a/djangocms_link/fields_select2.py
+++ b/djangocms_link/fields_select2.py
@@ -4,6 +4,8 @@ from cms.models import Page
 
 from django_select2.forms import ModelSelect2Widget
 
+from djangocms_link.helpers import get_queryset_manager
+
 
 class Select2PageSearchFieldMixin:
     search_fields = [
@@ -28,15 +30,10 @@ class Select2PageSelectWidget(Select2PageSearchFieldMixin, ModelSelect2Widget):
 
     def get_queryset(self):
         # django CMS < 4
-        if hasattr(Page.objects, "drafts"):
-            if self.site:
-                return Page.objects.drafts().on_site(self.site)
-            return Page.objects.drafts()
-
-        # django CMS >= 4
+        base_queryset = get_queryset_manager(Page.objects)
         if self.site:
-            return Page.objects.on_site(self.site)
-        return Page.objects.all()
+            return base_queryset.on_site(self.site)
+        return base_queryset.all()
 
     # we need to implement jQuery ourselves, see #180
     class Media:

--- a/djangocms_link/fields_select2.py
+++ b/djangocms_link/fields_select2.py
@@ -27,6 +27,13 @@ class Select2PageSelectWidget(Select2PageSearchFieldMixin, ModelSelect2Widget):
         return attrs
 
     def get_queryset(self):
+        # django CMS < 4
+        if hasattr(Page.objects, "drafts"):
+            if self.site:
+                return Page.objects.drafts().on_site(self.site)
+            return Page.objects.drafts()
+        
+        # django CMS >= 4
         if self.site:
             return Page.objects.on_site(self.site)
         return Page.objects.all()

--- a/djangocms_link/fields_select2.py
+++ b/djangocms_link/fields_select2.py
@@ -28,8 +28,8 @@ class Select2PageSelectWidget(Select2PageSearchFieldMixin, ModelSelect2Widget):
 
     def get_queryset(self):
         if self.site:
-            return Page.objects.drafts().on_site(self.site)
-        return Page.objects.drafts()
+            return Page.objects.on_site(self.site)
+        return Page.objects.all()
 
     # we need to implement jQuery ourselves, see #180
     class Media:

--- a/djangocms_link/forms.py
+++ b/djangocms_link/forms.py
@@ -18,7 +18,7 @@ class LinkForm(ModelForm):
         # current site
         # this will work for PageSelectFormField
         from cms.models import Page
-        self.fields['internal_link'].queryset = Page.objects.drafts().on_site(site)
+        self.fields['internal_link'].queryset = Page.objects.on_site(site)
         # set the current site as a internal_link field instance attribute
         # this will be used by the field later to properly set up the queryset
         # this will work for PageSearchField

--- a/djangocms_link/forms.py
+++ b/djangocms_link/forms.py
@@ -3,6 +3,8 @@ from django.utils.translation import gettext_lazy as _
 
 from djangocms_attributes_field.widgets import AttributesWidget
 
+from djangocms_link.helpers import get_queryset_manager
+
 from .fields import PageSearchField
 from .models import Link
 
@@ -18,7 +20,7 @@ class LinkForm(ModelForm):
         # current site
         # this will work for PageSelectFormField
         from cms.models import Page
-        self.fields['internal_link'].queryset = Page.objects.on_site(site)
+        self.fields['internal_link'].queryset = get_queryset_manager(Page.objects).on_site(site)
         # set the current site as a internal_link field instance attribute
         # this will be used by the field later to properly set up the queryset
         # this will work for PageSearchField

--- a/djangocms_link/helpers.py
+++ b/djangocms_link/helpers.py
@@ -1,0 +1,4 @@
+def get_queryset_manager(base):
+    if hasattr(base, "drafts"):
+        return base.drafts()
+    return base

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,70 @@
+from django.apps import apps
+
+from cms import __version__
+
+DJANGO_CMS4 = not (__version__ < "4")
+DJANGOCMS_VERSIONING = apps.is_installed("djangocms_versioning")
+
+
+class TestFixture:
+    """Sets up generic setUp and tearDown methods for tests."""
+
+    def setUp(self):
+        self.language = "en"
+        self.superuser = self.get_superuser()
+        return super().setUp()
+
+    def tearDown(self):
+        if DJANGOCMS_VERSIONING:
+            from djangocms_versioning.models import Version
+
+            Version.objects.all().delete()
+        return super().tearDown()
+
+    if DJANGO_CMS4:  # CMS V4
+
+        def _get_version(self, grouper, version_state, language=None):
+            language = language or self.language
+
+            from djangocms_versioning.models import Version
+
+            versions = Version.objects.filter_by_grouper(grouper).filter(
+                state=version_state
+            )
+            for version in versions:
+                if (
+                    hasattr(version.content, "language")
+                    and version.content.language == language
+                ):
+                    return version
+            return None
+
+        def publish(self, grouper, language=None):
+            if DJANGOCMS_VERSIONING:
+                from djangocms_versioning.constants import DRAFT
+
+                version = self._get_version(grouper, DRAFT, language)
+                if version is not None:
+                    version.publish(self.superuser)
+
+        def unpublish(self, grouper, language=None):
+            if DJANGOCMS_VERSIONING:
+                from djangocms_versioning.constants import PUBLISHED
+
+                version = self._get_version(grouper, PUBLISHED, language)
+                if version is not None:
+                    version.unpublish(self.superuser)
+
+        def get_placeholders(self, page, language=None):
+            return page.get_placeholders(language or self.language)
+
+    else:  # CMS V3
+
+        def publish(self, page, language=None):
+            page.publish(language)
+
+        def unpublish(self, page, language=None):
+            page.unpublish(language)
+
+        def get_placeholders(self, page, language=None):
+            return page.get_placeholders()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -2,6 +2,7 @@ from django.apps import apps
 
 from cms import __version__
 
+
 DJANGO_CMS4 = not (__version__ < "4")
 DJANGOCMS_VERSIONING = apps.is_installed("djangocms_versioning")
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -28,6 +28,7 @@ HELPER_SETTINGS = {
         ('static_placeholder.html', 'Page with static placeholder'),
     ),
     'FILE_UPLOAD_TEMP_DIR': mkdtemp(),
+    'CMS_CONFIRM_VERSION4': True
 }
 
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -26,5 +26,5 @@ class MigrationTestCase(TestCase):
             # the "no changes" exit code is 0
             status_code = '0'
 
-        if status_code == '1':
+        if status_code == '1' and "djangocms_link" in output:
             self.fail(f'There are missing migrations:\n {output.getvalue()}')

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -10,9 +10,10 @@ from djangocms_link.cms_plugins import LinkPlugin
 from djangocms_link.models import AbstractLink
 
 from .helpers import get_filer_file
+from .fixtures import TestFixture
 
 
-class LinkPluginsTestCase(CMSTestCase):
+class LinkPluginsTestCase(TestFixture, CMSTestCase):
 
     def setUp(self):
         self.file = get_filer_file()
@@ -22,19 +23,19 @@ class LinkPluginsTestCase(CMSTestCase):
             template="page.html",
             language=self.language,
         )
-        self.home.publish(self.language)
+        self.publish(self.home, self.language)
         self.page = create_page(
             title="content",
             template="page.html",
             language=self.language,
         )
-        self.page.publish(self.language)
+        self.publish(self.page, self.language)
         self.static_page = create_page(
             title='static-content',
             template='static_placeholder.html',
             language='en',
         )
-        self.placeholder = self.page.placeholders.get(slot="content")
+        self.placeholder = self.get_placeholders(self.page, self.language).get(slot="content")
         self.superuser = self.get_superuser()
 
     def tearDown(self):
@@ -64,7 +65,7 @@ class LinkPluginsTestCase(CMSTestCase):
             internal_link=self.page,
             name="Page link",
         )
-        self.page.publish(self.language)
+        self.publish(self.page, self.language)
         self.assertEqual(plugin.get_plugin_class_instance().name, "Link")
 
         with self.login_user_context(self.superuser):
@@ -97,7 +98,7 @@ class LinkPluginsTestCase(CMSTestCase):
         AbstractLink.link_is_optional = True
 
         plugin = add_plugin(
-            self.page.placeholders.get(slot='content'),
+            self.get_placeholders(self.page, self.language).get(slot='content'),
             'LinkPlugin',
             'en',
         )
@@ -108,7 +109,7 @@ class LinkPluginsTestCase(CMSTestCase):
         self.assertEqual(AbstractLink.link_is_optional, False)
 
         plugin = add_plugin(
-            self.page.placeholders.get(slot='content'),
+            self.get_placeholders(self.page, self.language).get(slot='content'),
             'LinkPlugin',
             'en',
         )
@@ -119,7 +120,7 @@ class LinkPluginsTestCase(CMSTestCase):
 
     def test_in_placeholders(self):
         plugin = add_plugin(
-            self.page.placeholders.get(slot='content'),
+            self.get_placeholders(self.page, self.language).get(slot='content'),
             'LinkPlugin',
             'en',
             internal_link=self.page,
@@ -164,7 +165,7 @@ class LinkPluginsTestCase(CMSTestCase):
 
     def test_file(self):
         plugin = add_plugin(
-            self.page.placeholders.get(slot="content"),
+            self.get_placeholders(self.page, self.language).get(slot="content"),
             "LinkPlugin",
             "en",
             file_link=self.file,

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -9,8 +9,8 @@ from cms.test_utils.testcases import CMSTestCase
 from djangocms_link.cms_plugins import LinkPlugin
 from djangocms_link.models import AbstractLink
 
-from .helpers import get_filer_file
 from .fixtures import TestFixture
+from .helpers import get_filer_file
 
 
 class LinkPluginsTestCase(TestFixture, CMSTestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     isort
     py{38,39,310}-dj{32}-cms{310,311}
     py{38,39,310}-dj{40}-cms{311}
+    py{39,310}-dj{40,42}-cms{41}
 
 skip_missing_interpreters=True
 
@@ -12,8 +13,10 @@ deps =
     -r{toxinidir}/tests/requirements/base.txt
     dj32: Django>=3.2,<4.0
     dj40: Django>=4.0,<4.1
+    dj42: Djago>=4.2,<5.0
     cms310: django-cms>=3.10,<3.11
     cms311: django-cms>=3.11,<3.12
+    cms41: django-cms>=4.1,<4.2
 commands =
     {envpython} --version
     {env:COMMAND:coverage} erase

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     -r{toxinidir}/tests/requirements/base.txt
     dj32: Django>=3.2,<4.0
     dj40: Django>=4.0,<4.1
-    dj42: Djago>=4.2,<5.0
+    dj42: Django>=4.2,<5.0
     cms310: django-cms>=3.10,<3.11
     cms311: django-cms>=3.11,<3.12
     cms41: django-cms>=4.1,<4.2


### PR DESCRIPTION
## Description

This PR adds support for the new djangoCMS 4.x.
It closes #221 and uses the outlined approach discussed there.

I also refactored the test setup and added the Mixin/Fixture of djangocms-text-ckeditor4 to support both djangoCMS 3 & 4.

All tests are green locally, I'd be happy to get this merged if everything is looking good to you @fsbraun :)

## Related resources

* https://github.com/django-cms/djangocms-text-ckeditor/blob/master/tests/fixtures.py

## Checklist

* [ x ] I have opened this pull request against ``master``
* [ x ] I have added or modified the tests when changing logic
* [ x ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ x ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
