### PR TITLE
chore: Add tests for django CMS 5.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
           dj50_cms311.txt,
           dj50_cms41.txt,
           dj51_cms41.txt,
-          dj52_cms51.txt,
+          dj52_cms41.txt,
           dj52_cms50.txt,
         ]
         os: [

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,11 @@ jobs:
           dj50_cms311.txt,
           dj50_cms41.txt,
           dj51_cms41.txt,
+          dj52_cms51.txt,
+          dj52_cms50.txt,
         ]
         os: [
-          ubuntu-20.04,
+          ubuntu-latest,
         ]
         exclude:
           - requirements-file: dj50_cms311.txt

--- a/djangocms_link/admin.py
+++ b/djangocms_link/admin.py
@@ -144,7 +144,7 @@ class AdminUrlsView(BaseListView):
         """Return queryset based on ModelAdmin.get_search_results()."""
         languages = get_language_list()
         try:
-            # django CMS 4.2+
+            # django CMS 5.0+
             qs = (
                 PageContent.admin_manager.filter(language__in=languages)
                 .filter(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ packages = [ "djangocms_link" ]
 [tool.setuptools.dynamic]
 version = { attr = "djangocms_link.__version__" }
 
+[tool.setuptools.package-data]
+djangocms_link = [ "static/", "templates/", "locale/", "LICENSE", "README.rst" ]
+
 [tool.isort]
 line_length = 119
 skip = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ packages = [ "djangocms_link" ]
 version = { attr = "djangocms_link.__version__" }
 
 [tool.setuptools.package-data]
-djangocms_link = [ "static/", "templates/", "locale/", "LICENSE", "README.rst" ]
+djangocms_link = [ "static/**/*", "templates/**/*", "locale/**/*", "LICENSE", "README.rst" ]
 
 [tool.isort]
 line_length = 119

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -68,7 +68,7 @@ class LinkEndpointTestCase(CMSTestCase):
                     self.assertIn("url", page)
                     _, pk = page["id"].split(":")
                     db_page = Page.objects.get(pk=pk)
-                    self.assertEqual(page["text"], str(db_page))
+                    self.assertEqual(page["text"], str(db_page.get_admin_content("en").title))
         admin.REGISTERED_ADMIN = registered
 
     def test_filter(self):

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -59,7 +59,6 @@ class LinkEndpointTestCase(CMSTestCase):
                 self.assertEqual(len(data["results"]), 1)
                 self.assertIn("pagination", data)
                 self.assertEqual(data["pagination"]["more"], False)
-
                 pages = data["results"][0]
                 self.assertEqual(pages["text"], "Pages")
                 for page in pages["children"]:
@@ -68,7 +67,11 @@ class LinkEndpointTestCase(CMSTestCase):
                     self.assertIn("url", page)
                     _, pk = page["id"].split(":")
                     db_page = Page.objects.get(pk=pk)
-                    self.assertEqual(page["text"], str(db_page.get_admin_content("en").title))
+                    try:
+                        expected = str(db_page.get_admin_content("en").title)
+                    except AttributeError:
+                        expected = str(db_page)
+                    self.assertEqual(page["text"], expected)
         admin.REGISTERED_ADMIN = registered
 
     def test_filter(self):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -121,7 +121,7 @@ class LinkFieldTestCase(TestCase):
         )
 
         self.assertIn(
-            '<option value="cms.page:1" selected>django CMS is fun</option>',
+            f'<option value="cms.page:1" selected>{str(self.page)}</option>',
             rendered_widget,
         )
 


### PR DESCRIPTION
## Description

Add Django CMS 5 tests

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Add compatibility and testing updates for django CMS 5.0 by expanding the CI matrix, including package data in the build, updating admin comments, and adjusting tests to use the new admin content API.

Enhancements:
- Update admin code comment to reflect django CMS 5.0 compatibility

Build:
- Add package data to pyproject.toml for static files, templates, locale, LICENSE, and README

CI:
- Expand GitHub Actions test matrix to include Django 3.2 with CMS 5.1 and 5.0 and switch to ubuntu-latest runner

Tests:
- Adapt endpoint and field tests for Django CMS 5.0 by using `get_admin_content("en").title` and `str(self.page)` in assertions