### PR TITLE
feat: allow model objects as parameter of `to_url` template tag.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -239,7 +239,7 @@ cached.)::
 Link models
 -----------
 
-The ``to_url`` template tag and the ``get_obj_link`` helper function can be used to
+The ``to_url`` template filter and the ``get_obj_link`` helper function can be used to
 get the full rul for any Django model instance. This is useful on multi-site installations.
 ``to_url`` assumes that the model instance's site is found in its ``site`` property. If the
 model belongs to a different site than the current, it prepends the domain name of that site.
@@ -249,7 +249,7 @@ Example::
     {% load djangocms_link_tags %}
 
     {% if obj %}
-        <a href="{% to_url obj %}">Link to object</a>  {# will include the site domain if needed #}
+        <a href="{{ obj|to_url }}">Link to object</a>  {# will include the site domain if needed #}
     {% endif %}
 
 Running Tests

--- a/README.rst
+++ b/README.rst
@@ -240,7 +240,7 @@ Link models
 -----------
 
 The ``to_url`` template filter and the ``get_obj_link`` helper function can be used to
-get the full rul for any Django model instance. This is useful on multi-site installations.
+get the full url for any Django model instance. This is useful on multi-site installations.
 ``to_url`` assumes that the model instance's site is found in its ``site`` property. If the
 model belongs to a different site than the current, it prepends the domain name of that site.
 

--- a/README.rst
+++ b/README.rst
@@ -152,8 +152,18 @@ The default is 50::
     # Show 100 results per "page"
     DJANGOCMS_LINK_PAGINATE_BY = 100
 
-Note, that in the admin paginated search results repeat the modle verbose name.
+Note, that in the admin paginated search results repeat the modle's verbose name.
 
+
+Site-selectors
+..............
+
+For multi-site installations, django CMS Link provides a site selector. It can be
+switched on or off by setting the ``DJANGOCMS_LINK_SITE_SELECTOR`` setting to
+``True`` or ``False``. The default is ``True``::
+
+    # Enable the site selector
+    DJANGOCMS_LINK_SITE_SELECTOR = True
 
 Non-standard hostnames
 ......................
@@ -226,6 +236,21 @@ cached.)::
     obj = MyModel.objects.first()
     url = obj.link.url
 
+Link models
+-----------
+
+The ``to_url`` template tag and the ``get_obj_link`` helper function can be used to
+get the full rul for any Django model instance. This is useful on multi-site installations.
+``to_url`` assumes that the model instance's site is found in its ``site`` property. If the
+model belongs to a different site than the current, it prepends the domain name of that site.
+
+Example::
+
+    {% load djangocms_link_tags %}
+
+    {% if obj %}
+        <a href="{% to_url obj %}">Link to object</a>  {# will include the site domain if needed #}
+    {% endif %}
 
 Running Tests
 -------------

--- a/README.rst
+++ b/README.rst
@@ -152,7 +152,7 @@ The default is 50::
     # Show 100 results per "page"
     DJANGOCMS_LINK_PAGINATE_BY = 100
 
-Note, that in the admin paginated search results repeat the modle's verbose name.
+Note, that in the admin paginated search results repeat the model's verbose name.
 
 
 Site-selectors

--- a/djangocms_link/admin.py
+++ b/djangocms_link/admin.py
@@ -40,7 +40,7 @@ class AdminUrlsView(BaseListView):
     def get(self, request, *args, **kwargs):
         """
         Return a JsonResponse with search results (query parameter "q") usable by
-        Django admin's autocomplete view. Each item is returned as defined in 
+        Django admin's autocomplete view. Each item is returned as defined in
         serialize_result(), for example:
         {
             "results": [
@@ -58,10 +58,10 @@ class AdminUrlsView(BaseListView):
              ],
              "pagination": {"more": true}
         }
-        
+
         If the endpoint is called with the query parameter "g" (for get), the view will
-        search for the id (e.g., "cms.page:5") and return its entry as defined in 
-        serialize_results(), e.g.: 
+        search for the id (e.g., "cms.page:5") and return its entry as defined in
+        serialize_results(), e.g.:
         {
              "id": "cms.page:5",
              "text": "My first page",

--- a/djangocms_link/helpers.py
+++ b/djangocms_link/helpers.py
@@ -28,7 +28,7 @@ def get_rel_obj(internal_link: str) -> models.Model | None:
         return get_manager(model).filter(pk=pk).first()
 
 
-def get_obj_link(obj: models.Model, site_id: int | None) -> str:
+def get_obj_link(obj: models.Model, site_id: int | None = None) -> str:
     # Access site id if possible (no db access necessary)
     if site_id is None:
         site_id = Site.objects.get_current().id

--- a/djangocms_link/helpers.py
+++ b/djangocms_link/helpers.py
@@ -36,7 +36,7 @@ def get_obj_link(obj: models.Model, site_id: int | None) -> str:
         obj, "site_id", getattr(getattr(obj, "node", None), "site_id", None)
     )
     link = obj.get_absolute_url()  # Can be None
-    if obj_site_id and obj_site_id != site_id:
+    if link and obj_site_id and obj_site_id != site_id:
         ref_site = Site.objects._get_site_by_id(obj_site_id).domain
         link = f"//{ref_site}{link}"
     return link

--- a/djangocms_link/templatetags/djangocms_link_tags.py
+++ b/djangocms_link/templatetags/djangocms_link_tags.py
@@ -1,6 +1,7 @@
 from django import template
+from django.db import models
 
-from djangocms_link.helpers import LinkDict, get_link
+from djangocms_link.helpers import LinkDict, get_link, get_obj_link
 
 
 try:
@@ -16,7 +17,11 @@ register = template.Library()
 
 @register.filter
 def to_url(value):
-    return get_link(value) or ""
+    if isinstance(value, models.Model):
+        return get_obj_link(value) or ""
+    elif isinstance(value, dict):
+        return get_link(value) or ""
+    return ""
 
 
 @register.filter

--- a/tests/test_link_dict.py
+++ b/tests/test_link_dict.py
@@ -97,3 +97,21 @@ class LinkDictTestCase(TestCase):
 
         # Cache not saved to db
         self.assertNotIn("__cache__", link.link)
+
+    def test_get_link_for_obj(self):
+        from cms.api import create_page
+
+        from djangocms_link.helpers import get_obj_link
+
+        page = create_page(
+            title="Test Page",
+            template="page.html",
+            slug="test-page",
+            language="en",
+        )
+
+        link = get_obj_link(page, site_id=None)
+        self.assertEqual(link, page.get_absolute_url())
+
+        link = get_obj_link(page, site_id=2)
+        self.assertEqual(link, f"//example.com{page.get_absolute_url()}")

--- a/tests/test_link_dict.py
+++ b/tests/test_link_dict.py
@@ -120,3 +120,9 @@ class LinkDictTestCase(TestCase):
         with override_settings(SITE_ID=2):
             rendered = template.render(Context({"page": page}))
         self.assertEqual(rendered, f"//example.com{page.get_absolute_url()}")
+
+        rendered = template.render(Context({"page": None}))  # Illegal value: fail silently
+        self.assertEqual(rendered, "")
+
+        rendered = template.render(Context({"page": LinkDict("tel:+1234567890")}))
+        self.assertEqual(rendered, "tel:+1234567890")


### PR DESCRIPTION
## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Support passing model objects to the to_url template filter by extracting URL logic into a get_obj_link helper and refactoring get_link to use it, and add tests for cross-site URL rendering

New Features:
- Add get_obj_link helper to compute absolute URLs for model objects
- Extend to_url template tag to accept model instances as parameters

Enhancements:
- Refactor get_link to delegate URL generation to get_obj_link

Tests:
- Add tests for the to_url filter with model objects, including cross-site URL prefixing