### PR TITLE
add relative_link to link field

### DIFF
--- a/djangocms_link/helpers.py
+++ b/djangocms_link/helpers.py
@@ -49,6 +49,8 @@ def get_link(link_field_value: dict, site_id: int | None = None) -> str | None:
         if link_field_value["external_link"].startswith("tel:"):
             return link_field_value["external_link"].replace(" ", "")
         return link_field_value["external_link"] or None
+    elif "relative_link" in link_field_value:
+        return link_field_value["relative_link"] or None
 
     if "__cache__" in link_field_value:
         return link_field_value["__cache__"] or None
@@ -82,7 +84,10 @@ class LinkDict(dict):
             if isinstance(initial, dict):
                 self.update(initial)
             elif isinstance(initial, str):
-                self["external_link"] = initial
+                if initial.startswith("/"):
+                    self["relative_link"] = initial
+                else:
+                    self["external_link"] = initial
             elif isinstance(initial, File):
                 self["file_link"] = initial.pk
             elif isinstance(initial, models.Model):
@@ -100,7 +105,7 @@ class LinkDict(dict):
 
     @property
     def type(self) -> str:
-        for key in ("internal_link", "file_link"):
+        for key in ("relative_link", "internal_link", "file_link"):
             if key in self:
                 return key
         if "external_link" in self:

--- a/djangocms_link/static/djangocms_link/link-widget.css
+++ b/djangocms_link/static/djangocms_link/link-widget.css
@@ -12,7 +12,7 @@
             min-width: unset;
         }
     }
-    .external_link, .internal_link, .file_link, .anchor, .site {
+    .external_link, .relative_link, .internal_link, .file_link, .anchor, .site {
         display: none;
         padding: 0;
         select, input {
@@ -23,7 +23,8 @@
             width: 100% !important;
         }
     }
-    .external_link {
+    .external_link,
+    .relative_link {
         width: 75%;
     }
     .internal_link {
@@ -37,6 +38,7 @@
         margin-top: 0.5em;
     }
     &[data-type="external_link"] .external_link,
+    &[data-type="relative_link"] .relative_link,
     &[data-type="internal_link"] .internal_link,
     &[data-type="internal_link"] .site,
     &[data-type="internal_link"] .anchor

--- a/djangocms_link/validators.py
+++ b/djangocms_link/validators.py
@@ -110,3 +110,32 @@ class ExtendedURLValidator(IntranetURLValidator):
         ):
             return EmailValidator()(value[7:])
         return super().__call__(value)
+
+
+@deconstructible
+class RelativeURLValidator:
+    message = _("Enter a valid realtive link")
+    code = "invalid"
+
+    def __init__(self, allowed_link_types: list = None, **kwargs):
+        self.allowed_link_types = allowed_link_types
+        super().__init__(**kwargs)
+
+    def __call__(self, value: str):
+        if not isinstance(value, str) or len(value) > URLValidator.max_length:
+            raise ValidationError(self.message, code=self.code, params={"value": value})
+        if URLValidator.unsafe_chars.intersection(value):
+            raise ValidationError(self.message, code=self.code, params={"value": value})
+        if (
+            value.startswith("/") and (
+                self.allowed_link_types is not None
+                and "relative_link" not in self.allowed_link_types
+            )
+            or not value.startswith("/")
+        ):
+            raise ValidationError(
+                self.message,
+                code=self.code,
+                params={"value": value},
+            )
+        return value

--- a/djangocms_link/validators.py
+++ b/djangocms_link/validators.py
@@ -114,7 +114,7 @@ class ExtendedURLValidator(IntranetURLValidator):
 
 @deconstructible
 class RelativeURLValidator:
-    message = _("Enter a valid realtive link")
+    message = _("Enter a valid relative link")
     code = "invalid"
 
     def __init__(self, allowed_link_types: list = None, **kwargs):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -33,20 +33,29 @@ class LinkFieldTestCase(TestCase):
             '<select name="link_field_0" class="js-link-widget-selector" data-help="No destination selected. '
             'Use the dropdown to select a destination." required id="id_link_field_0">'
             '<option value="internal_link">Internal link</option>'
+            '<option value="relative_link">Relative link</option>'
             '<option value="external_link">External link/anchor</option>'
             '<option value="file_link">File link</option></select>',
             form_html,
         )
         # Render internal URL field
         self.assertIn(
-            '<select name="link_field_2" widget="internal_link" '
+            '<select name="link_field_3" widget="internal_link" '
             'data-help="Select from available internal destinations. Optionally, add an anchor to scroll to." '
-            'data-placeholder="" required id="id_link_field_2" class="admin-autocomplete" data-ajax--cache="true" '
+            'data-placeholder="" required id="id_link_field_3" class="admin-autocomplete" data-ajax--cache="true" '
             'data-ajax--delay="250" data-ajax--type="GET" data-ajax--url="/en/admin/djangocms_link/link/urls" '
             'data-theme="admin-autocomplete" data-allow-clear="true" '
             'data-minimum-input-length="0" lang="en">'
             '<option value=""></option><option value="" selected>None</option>'
             "</select>",
+            form_html,
+        )
+        # Render relative URL field
+        self.assertIn(
+            '<input type="text" name="link_field_2" widget="relative_link" '
+            'placeholder="/some/path - optionally append #anchor" '
+            'data-help="Provide a relative link. Optionally, add an #anchor (including the #) to scroll to." '
+            'required id="id_link_field_2">',
             form_html,
         )
         # Render external URL field
@@ -68,6 +77,7 @@ class LinkFieldTestCase(TestCase):
             'Use the dropdown to select a destination." id="id_link_field_0">'
             '<option value="empty">---------</option>'
             '<option value="internal_link">Internal link</option>'
+            '<option value="relative_link">Relative link</option>'
             '<option value="external_link">External link/anchor</option>'
             '<option value="file_link">File link</option></select>',
             str(LinkNotRequiredForm()),
@@ -91,6 +101,7 @@ class LinkFieldTestCase(TestCase):
             self.assertEqual(form.cleaned_data["link_field"], value)
 
         check_value({"internal_link": f"cms.page:{self.page.id}", "anchor": "#anchor"})
+        check_value({"relative_link": "/some/path"})
         check_value({"external_link": "https://example.com"})
         check_value({"external_link": "#anchor"})
         check_value({"file_link": str(self.file.id)})
@@ -101,7 +112,15 @@ class LinkFieldTestCase(TestCase):
             link_field = LinkFormField(required=False)
 
         form = LinkForm(initial={"link_field": {"internal_link": f"cms.page:{self.page.id}"}})
-        self.assertEqual(form["link_field"].value(), ["internal_link", None, f"cms.page:{self.page.id}", "", None])
+        self.assertEqual(form["link_field"].value(), ["internal_link", None, None, f"cms.page:{self.page.id}", "", None])
+
+    def test_form_field_initial_works_relative(self):
+        class LinkForm(forms.Form):
+            link_field = LinkFormField(required=False)
+
+        some_string = "/some/path"
+        form = LinkForm(initial={"link_field": {"relative_link": some_string}})
+        self.assertEqual(form["link_field"].value(), ["relative_link", None, some_string, None, None, None])
 
     def test_form_field_initial_works_external(self):
         class LinkForm(forms.Form):
@@ -109,13 +128,13 @@ class LinkFieldTestCase(TestCase):
 
         some_string = "https://example.com"
         form = LinkForm(initial={"link_field": {"external_link": some_string}})
-        self.assertEqual(form["link_field"].value(), ["external_link", some_string, None, None, None])
+        self.assertEqual(form["link_field"].value(), ["external_link", some_string, None, None, None, None])
 
     def test_widget_renders_selection(self):
         widget = LinkWidget()
         pre_select_page = len(widget.widgets) * [None]
         pre_select_page[0] = "internal_link"
-        pre_select_page[2] = f"cms.page:{self.page.id}"
+        pre_select_page[3] = f"cms.page:{self.page.id}"
         rendered_widget = widget.render(
             "link_field", pre_select_page, attrs={"id": "id_link_field"}
         )
@@ -129,14 +148,14 @@ class LinkFieldTestCase(TestCase):
         widget = LinkWidget(site_selector=True)
         pre_select_page = len(widget.widgets) * [None]
         pre_select_page[0] = "internal_link"
-        pre_select_page[2] = f"cms.page:{self.page.id}"
+        pre_select_page[3] = f"cms.page:{self.page.id}"
         rendered_widget = widget.render(
             "link_field", pre_select_page, attrs={"id": "id_link_field"}
         )
 
         # Subwidget is present
         self.assertIn(
-            '<select name="link_field_2" class="js-link-site-widget admin-autocomplete" widget="site"',
+            '<select name="link_field_3" class="js-link-site-widget admin-autocomplete" widget="site"',
             rendered_widget,
         )
         # Current site is pre-selected

--- a/tests/test_link_dict.py
+++ b/tests/test_link_dict.py
@@ -31,6 +31,17 @@ class LinkDictTestCase(TestCase):
         self.assertEqual(link1.type, "external_link")
         self.assertEqual(link2.type, "external_link")
 
+    def test_relative_link(self):
+        link1 = LinkDict({"relative_link": "/some/path"})
+        link2 = LinkDict("/other/path")
+
+        self.assertEqual(link1.url, "/some/path")
+        self.assertEqual(link2.url, "/other/path")
+        self.assertEqual(str(link1), "/some/path")
+        self.assertEqual(str(link2), "/other/path")
+        self.assertEqual(link1.type, "relative_link")
+        self.assertEqual(link2.type, "relative_link")
+
     def test_file_link(self):
         file = File.objects.create(file=get_random_string(5))
         link1 = LinkDict({"file_link": file.pk})

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -23,6 +23,13 @@ class LinkModelTestCase(TestCase):
             target=TARGET_CHOICES[0][0],
             attributes="{'data-type', 'link'}",
         )
+        self.relative_link = Link.objects.create(
+            template="default",
+            name="My Link",
+            link={"relative_link": "/some/path#some_id"},
+            target=TARGET_CHOICES[0][0],
+            attributes="{'data-type', 'link'}",
+        )
         self.external_link = Link.objects.create(
             template="default",
             name="My Link",
@@ -65,7 +72,7 @@ class LinkModelTestCase(TestCase):
 
     def test_link_instance(self):
         instances = Link.objects.all()
-        self.assertEqual(instances.count(), 6)  # 4 instances created in setUp
+        self.assertEqual(instances.count(), 7)  # 7 instances created in setUp
 
         instance = Link.objects.first()
         self.assertEqual(instance.template, "default")
@@ -98,6 +105,9 @@ class LinkModelTestCase(TestCase):
         )
         self.assertEqual(self.file_link.get_link(), self.file.url)
         self.assertEqual(
+            self.relative_link.get_link(), "/some/path#some_id"
+        )
+        self.assertEqual(
             self.external_link.get_link(), "https://www.django-cms.org/#some_id"
         )
         self.assertEqual(self.phone_link.get_link(), "tel:+0123456789")
@@ -111,6 +121,9 @@ class LinkModelTestCase(TestCase):
             to_url(self.internal_link.link), self.page.get_absolute_url() + "#some_id"
         )
         self.assertEqual(to_url(self.file_link.link), self.file.url)
+        self.assertEqual(
+            to_url(self.relative_link.link), "/some/path#some_id"
+        )
         self.assertEqual(
             to_url(self.external_link.link), "https://www.django-cms.org/#some_id"
         )
@@ -129,6 +142,10 @@ class LinkModelTestCase(TestCase):
                 "internal_link": f"cms.page:{self.page.pk}",
                 "__cache__": self.page.get_absolute_url(),
             }
+        )
+        self.assertEqual(
+            to_link("/some/path#some_id"),
+            {"relative_link": "/some/path#some_id"},
         )
         self.assertEqual(
             to_link("https://www.django-cms.org/#some_id"),


### PR DESCRIPTION
## Description

Provide functionality to link internal pages not directly accessible via 'internal_link', e.g. apphook-urls.

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Add full support for a new "relative_link" link type by extending the link widget, form field, validators, models, helpers, and tests to handle relative URLs.

New Features:
- Introduce support for a "relative_link" option in the link field widget and form field
- Add RelativeURLValidator to enforce valid relative URL inputs
- Extend LinkDict and get_link/to_link helpers to handle relative links

Enhancements:
- Include "relative_link" in the default allowed link types and widget optgroups
- Update link-widget CSS to display and style the relative_link input

Tests:
- Add tests for rendering, initial values, validation, model persistence, template tags, and LinkDict behavior for relative_link