### PR TITLE
fix: Optimized multi-qs evaluation for search fields

### DIFF
--- a/djangocms_link/admin.py
+++ b/djangocms_link/admin.py
@@ -13,6 +13,7 @@ from django.views.generic.list import BaseListView
 from cms import __version__
 from cms.models import Page
 from cms.utils import get_language_from_request, get_language_list
+from cms.utils.i18n import get_fallback_languages
 
 from . import models
 from .fields import LinkFormField, LinkWidget
@@ -113,15 +114,18 @@ class AdminUrlsView(BaseListView):
         if len(qs_list) == 1:
             # Only one qs, just use regular pagination
             return qs_list[0]
-        # Slize all querysets, evaluate and join them into a list
+        # Slice all querysets, evaluate and join them into a list.
+        # Collect one extra item so Django's paginator can detect has_next().
         max_items = self.get_page() * self.paginate_by
         objects = []
         for qs in qs_list:
             for item in qs:
                 if self.has_perm(self.request, item):
                     objects.append(item)
+                    if len(objects) > max_items:
+                        break
 
-            if len(objects) >= max_items:
+            if len(objects) > max_items:
                 # No need to touch the rest of the querysets
                 # as we have enough items already
                 break
@@ -191,6 +195,7 @@ class AdminUrlsView(BaseListView):
     def get_queryset(self) -> QuerySet:
         """Return queryset based on ModelAdmin.get_search_results()."""
         languages = get_language_list()
+        display_languages = self.get_display_languages()
         try:
             # django CMS 4.1/5.0+
             content_qs = (
@@ -207,7 +212,9 @@ class AdminUrlsView(BaseListView):
                     Prefetch(
                         "pagecontent_set",
                         to_attr="prefetched_content",
-                        queryset=PageContent.admin_manager.current_content(),
+                        queryset=PageContent.admin_manager.filter(
+                            language__in=display_languages
+                        ).current_content(),
                     ),
                 )
             )
@@ -233,7 +240,9 @@ class AdminUrlsView(BaseListView):
                     Prefetch(
                         "title_set",
                         to_attr="prefetched_content",
-                        queryset=get_manager(PageContent, current_content=True).all(),
+                        queryset=get_manager(
+                            PageContent, current_content=True
+                        ).filter(language__in=display_languages),
                     ),
                 )
             )
@@ -248,6 +257,11 @@ class AdminUrlsView(BaseListView):
             if self.site:
                 qs = qs.filter(node__site_id=self.site)
         return qs
+
+    def get_display_languages(self) -> list[str]:
+        languages = [self.language]
+        languages.extend(get_fallback_languages(self.language, self.site))
+        return list(dict.fromkeys(languages))
 
     def add_admin_querysets(self, qs: list[QuerySet]) -> None:
         for model_admin in REGISTERED_ADMIN:

--- a/djangocms_link/static/djangocms_link/link-widget.js
+++ b/djangocms_link/static/djangocms_link/link-widget.js
@@ -28,15 +28,11 @@ document.addEventListener('DOMContentLoaded' , () => {
 
     // If site widget changes, clear internal link widget
     for (let item of document.querySelectorAll('.js-link-site-widget')) {
-        console.warn(item);
         django.jQuery(item).on('change', e => {
             const site_select2 = django.jQuery(e.target);
             const internal_link_select2 = site_select2.closest('.link-widget').find('[widget="internal_link"]');
             internal_link_select2.attr('data-app-label', site_select2.val());
             internal_link_select2.val(null).trigger('change');
-        });
-        item.addEventListener("change", (e) => {
-            console.warn(e.target.closest('.link-widget').querySelector('[widget="internal_link"]'));
         });
     }
 });

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -331,6 +331,34 @@ class LinkEndpointThirdPartyTestCase(CMSTestCase):
         self.assertEqual(destinations["text"], "Third party models")
         self.assertEqual(len(destinations["children"]), 1)
 
+    def test_multi_queryset_pagination_stops_after_page_limit(self):
+        from djangocms_link.admin import AdminUrlsView
+
+        class TrackingIterable:
+            def __init__(self):
+                self.iterated = 0
+
+            def __iter__(self):
+                for item in self.items:
+                    self.iterated += 1
+                    yield item
+
+        first_qs = TrackingIterable()
+        first_qs.items = self.items
+        second_qs = TrackingIterable()
+        second_qs.items = self.items
+        view = AdminUrlsView()
+        view.request = None
+        view.paginate_by = 1
+        view.kwargs = {"page": 1}
+        view.has_perm = lambda request, obj=None: True
+
+        objects = view.get_paginated_multi_qs([first_qs, second_qs])
+
+        self.assertEqual(objects, list(self.items[:2]))
+        self.assertEqual(first_qs.iterated, 2)
+        self.assertEqual(second_qs.iterated, 0)
+
     def test_invalid_page_number(self):
         with self.login_user_context(self.get_superuser()):
             response = self.client.get(self.endpoint + "?page=999")


### PR DESCRIPTION
## Summary by Sourcery

Optimize admin link search pagination and restrict link search results to relevant languages with fallbacks.

Enhancements:
- Stop evaluating additional querysets in multi-queryset pagination once enough items (plus one extra for has_next) have been collected.
- Limit prefetched page content for admin link search to the current language and its fallbacks for the active site.
- Introduce a helper to compute display languages including fallbacks for use in admin link queries.

Tests:
- Add a pagination test ensuring multi-queryset evaluation stops after reaching the page item limit.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.